### PR TITLE
docs(zod-validator): add usage docs for `zErrValidator`

### DIFF
--- a/packages/zod-validator/README.md
+++ b/packages/zod-validator/README.md
@@ -37,6 +37,37 @@ app.post(
 )
 ```
 
+Throw Error:
+
+throw a zod validate error instead of directly returning an error response.
+
+```ts
+// file: validator-wrapper.ts
+import { ZodSchema } from "zod";
+import type { ValidationTargets } from "hono";
+import { zValidator as zv } from "@hono/zod-validator";
+
+export const zValidator = <
+  T extends ZodSchema,
+  Target extends keyof ValidationTargets,
+>(
+  target: Target,
+  schema: T,
+) => zv(target, schema, (result, c) => {
+  if (!result.success) {
+    throw result.error
+  }
+})
+
+// usage
+import { zValidator } from './validator-wrapper'
+app.post(
+  '/post',
+  zValidator('json', schema)
+  //...
+)
+```
+
 ## Author
 
 Yusuke Wada <https://github.com/yusukebe>


### PR DESCRIPTION

throw a validating error instead of directly returning an error response.

close: https://github.com/honojs/middleware/issues/890

relate: https://github.com/honojs/middleware/pull/897
